### PR TITLE
FireFox Escape key press in FullScreen mode

### DIFF
--- a/src/angular-fullscreen.js
+++ b/src/angular-fullscreen.js
@@ -56,9 +56,7 @@
                  //Same code as in $element.on('fullscreenchange...
                   document.addEventListener("mozfullscreenchange",function() {
                      if(!Fullscreen.isEnabled()){
-                        console.log('Full screen change detected.')
                         $scope.$evalAsync(function(){
-                           console.log('removing isInFullScreen class');
                            $scope[$attrs.fullscreen] = false
                            $element.removeClass('isInFullScreen');
                         })

--- a/src/angular-fullscreen.js
+++ b/src/angular-fullscreen.js
@@ -52,6 +52,18 @@
             link : function ($scope, $element, $attrs) {
                // Watch for changes on scope if model is provided
                if ($attrs.fullscreen) {
+                 //Mozilla behaves differently, when user presses ESC key in full screen mode.
+                 //Same code as in $element.on('fullscreenchange...
+                  document.addEventListener("mozfullscreenchange",function() {
+                     if(!Fullscreen.isEnabled()){
+                        console.log('Full screen change detected.')
+                        $scope.$evalAsync(function(){
+                           console.log('removing isInFullScreen class');
+                           $scope[$attrs.fullscreen] = false
+                           $element.removeClass('isInFullScreen');
+                        })
+                     }
+                  });                  
                   $scope.$watch($attrs.fullscreen, function(value) {
                      var isEnabled = Fullscreen.isEnabled();
                      if (value && !isEnabled) {


### PR DESCRIPTION
Browser FireFix: If the view is in fullscreen mode, and user presses ESC, directive won't detect the change, It wont be a fullscreen change on element, there will be one for document.